### PR TITLE
fix(ipam_driver): do not pass --ipam-driver option when value set to default

### DIFF
--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2852,37 +2852,6 @@ def compose_kill(compose, args):
         compose.podman.run([], "kill", podman_args)
 
 
-@cmd_run(
-    podman_compose,
-    "stats",
-    "Display percentage of CPU, memory, network I/O, block I/O and PIDs for services.",
-)
-def compose_stats(compose, args):
-    container_names_by_service = compose.container_names_by_service
-    if not args.services:
-        args.services = container_names_by_service.keys()
-    targets = []
-    podman_args = []
-    if args.interval:
-        podman_args.extend(["--interval", args.interval])
-    if args.format:
-        podman_args.extend(["--format", args.format])
-    if args.no_reset:
-        podman_args.append("--no-reset")
-    if args.no_stream:
-        podman_args.append("--no-stream")
-
-    for service in args.services:
-        targets.extend(container_names_by_service[service])
-    for target in targets:
-        podman_args.append(target)
-
-    try:
-        compose.podman.run([], "stats", podman_args)
-    except KeyboardInterrupt:
-        pass
-
-
 @cmd_run(podman_compose, "images", "List images used by the created containers")
 def compose_images(compose, args):
     img_containers = [cnt for cnt in compose.containers if "image" in cnt]
@@ -3409,35 +3378,6 @@ def compose_kill_parse(parser):
         "-a",
         "--all",
         help="Signal all running containers",
-        action="store_true",
-    )
-
-
-@cmd_parse(podman_compose, ["stats"])
-def compose_stats_parse(parser):
-    parser.add_argument(
-        "services", metavar="services", nargs="*", default=None, help="service names"
-    )
-    parser.add_argument(
-        "-i",
-        "--interval",
-        type=int,
-        help="Time in seconds between stats reports (default 5)",
-    )
-    parser.add_argument(
-        "-f",
-        "--format",
-        type=str,
-        help="Pretty-print container statistics to JSON or using a Go template",
-    )
-    parser.add_argument(
-        "--no-reset",
-        help="Disable resetting the screen between intervals",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--no-stream",
-        help="Disable streaming stats and only pull the first result",
         action="store_true",
     )
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -771,7 +771,7 @@ def assert_cnt_nets(compose, cnt):
                 args.extend(("--opt", f"{key}={value}"))
             ipam = net_desc.get("ipam", None) or {}
             ipam_driver = ipam.get("driver", None)
-            if ipam_driver:
+            if ipam_driver and ipam_driver not in ("default"):
                 args.extend(("--ipam-driver", ipam_driver))
             ipam_config_ls = ipam.get("config", None) or []
             if is_dict(ipam_config_ls):


### PR DESCRIPTION
podman returns unsupported ipam driver "default" when --imap-driver default parameter is passed.

So, when ipam driver is set to "default" in docker-compose.yml, --imap-driver must not be used when podman is called.